### PR TITLE
Fix share error

### DIFF
--- a/source/Gemini.API.pas
+++ b/source/Gemini.API.pas
@@ -972,7 +972,7 @@ var
 begin
   CheckAPI;
   Headers := GetHeaders;
-  var FileStream := TFileStream.Create(FileName, fmOpenRead);
+  var FileStream := TFileStream.Create(FileName, fmOpenRead or fmShareDenyWrite);
   Response := TStringStream.Create('', TEncoding.UTF8);
   try
     Code := FHTTPClient.Post(Path, FileStream, Response, Headers).StatusCode;


### PR DESCRIPTION
Fix share error if the file to be uploaded is open with read-only access, e.g., via a preview